### PR TITLE
#41: Verify content of the files

### DIFF
--- a/src/main/scala/za/co/absa/spark_metadata_tool/Application.scala
+++ b/src/main/scala/za/co/absa/spark_metadata_tool/Application.scala
@@ -115,6 +115,7 @@ object Application extends App {
   ): Either[AppError, Unit] = (for {
     _      <- logger.info(s"Processing file $path").asRight
     parsed <- metaTool.loadFile(path)
+    _      <- metaTool.verifyMetadataFileContent(path.toString, parsed)
     _      <- metaTool.backupFile(path, dryRun)
     fixed <-
       metaTool.fixPaths(parsed, newBasePath, firstPartitionKey).tap(_.logDebug(s"Fixed paths in file ${path.toString}"))

--- a/src/main/scala/za/co/absa/spark_metadata_tool/MetadataTool.scala
+++ b/src/main/scala/za/co/absa/spark_metadata_tool/MetadataTool.scala
@@ -32,6 +32,7 @@ import za.co.absa.spark_metadata_tool.model.MetadataFile
 import za.co.absa.spark_metadata_tool.model.NotFoundError
 import za.co.absa.spark_metadata_tool.model.StringLine
 import za.co.absa.spark_metadata_tool.model.IoError
+import za.co.absa.spark_metadata_tool.model.ParsingError
 
 import scala.util.Try
 import scala.util.chaining._
@@ -150,6 +151,7 @@ class MetadataTool(io: FileManager) {
 
   def merge(oldFiles: Seq[MetadataFile], targetFile: MetadataFile): Either[AppError, Seq[FileLine]] = for {
     targetFileContent <- loadFile(targetFile.path)
+    _ <- verifyMetadataFileContent(targetFile.path.toString, targetFileContent)
     version <- targetFileContent.headOption
                  .tap(v => logger.debug(s"Version value from the target file $targetFile: $v"))
                  .toRight(NotFoundError(s"No content in file ${targetFile.path}"))
@@ -158,6 +160,8 @@ class MetadataTool(io: FileManager) {
                   .tap(c => logger.debug(s"Will append ${c.size} lines from the target file $targetFile"))
                   .asRight
     oldFilesContent <- oldFiles.sorted.traverse(f => loadFile(f.path))
+    _ <- oldFiles.zip(oldFilesContent)
+           .traverse { case (file, content) => verifyMetadataFileContent(file.path.toString, content)}
     toPrepend <- oldFilesContent
                    .flatMap(_.drop(1))
                    .tap(c => logger.debug(s"Will merge ${c.size} lines from the old metadata files"))
@@ -244,6 +248,18 @@ class MetadataTool(io: FileManager) {
 
     logger.info(s"Ignored non metadata files: ${otherFiles.map(_.toString)}")
     metadataFiles.asRight[IoError]
+  }
+
+  def verifyMetadataFileContent(path: String, lines: Seq[FileLine]): Either[AppError, Unit] = {
+    def verifyJsonContent(lines: Seq[FileLine]): Boolean = lines.forall {
+      case line: JsonLine => line.cursor.keys.exists(_.toSeq.contains("path"))
+      case _ => false
+    }
+    lines match {
+      case (firstLine:StringLine)::(rest:Seq[FileLine])
+        if firstLine.value == "v1" && rest.nonEmpty && verifyJsonContent(rest) => Right((): Unit)
+      case _ => Left(ParsingError(s"File $path did not match expected format", None))
+    }
   }
 
 }

--- a/src/test/scala/za/co/absa/spark_metadata_tool/MetadataToolSpec.scala
+++ b/src/test/scala/za/co/absa/spark_metadata_tool/MetadataToolSpec.scala
@@ -31,6 +31,7 @@ import za.co.absa.spark_metadata_tool.model.JsonLine
 import za.co.absa.spark_metadata_tool.model.MetadataFile
 import za.co.absa.spark_metadata_tool.model.NotFoundError
 import za.co.absa.spark_metadata_tool.model.StringLine
+import za.co.absa.spark_metadata_tool.model.ParsingError
 
 import MetadataToolSpec._
 
@@ -418,6 +419,78 @@ class MetadataToolSpec extends AnyFlatSpec with Matchers with OptionValues with 
     res.value should contain theSameElementsAs metadataFiles
   }
 
+  "verifyMetadataFileContent" should "do nothing if file content is correct" in {
+    val path = hdfsBasePath.toString
+
+    val lines: Seq[FileLine] = Seq(
+      MetadataToolSpec.versionLine,
+      MetadataToolSpec.correctJsonLine,
+      MetadataToolSpec.correctJsonLine
+    )
+
+    val res = metadataTool.verifyMetadataFileContent(path, lines)
+
+    res.value shouldBe (): Unit
+  }
+
+  it should "fail if first line is json and not a version" in {
+    val path = hdfsBasePath.toString
+
+    val lines: Seq[FileLine] = Seq(MetadataToolSpec.correctJsonLine, MetadataToolSpec.correctJsonLine)
+
+    val expected = MetadataToolSpec.getParsingError(path)
+    val res = metadataTool.verifyMetadataFileContent(path, lines)
+
+    res.left.value shouldBe expected
+  }
+
+  it should "fail if first line is string and not a version" in {
+    val path = hdfsBasePath.toString
+
+    val lines: Seq[FileLine] = Seq(MetadataToolSpec.notJsonLine, MetadataToolSpec.correctJsonLine)
+
+    val expected = MetadataToolSpec.getParsingError(path)
+    val res = metadataTool.verifyMetadataFileContent(path, lines)
+
+    res.left.value shouldBe expected
+  }
+
+  it should "fail if json line is not a json" in {
+    val path = hdfsBasePath.toString
+
+    val lines: Seq[FileLine] = Seq(
+      MetadataToolSpec.versionLine,
+      MetadataToolSpec.correctJsonLine,
+      MetadataToolSpec.notJsonLine
+    )
+
+    val expected = MetadataToolSpec.getParsingError(path)
+    val res = metadataTool.verifyMetadataFileContent(path, lines)
+
+    res.left.value shouldBe expected
+  }
+
+  it should "fail if json line does not contain path key" in {
+    val path = hdfsBasePath.toString
+
+    val lines: Seq[FileLine] = Seq(MetadataToolSpec.versionLine, MetadataToolSpec.incorrectJsonLine)
+
+    val expected = MetadataToolSpec.getParsingError(path)
+    val res = metadataTool.verifyMetadataFileContent(path, lines)
+
+    res.left.value shouldBe expected
+  }
+
+  it should "fail if file is empty" in {
+    val path = hdfsBasePath.toString
+
+    val lines: Seq[FileLine] = Seq()
+
+    val expected = MetadataToolSpec.getParsingError(path)
+    val res = metadataTool.verifyMetadataFileContent(path, lines)
+
+    res.left.value shouldBe expected
+  }
 }
 
 object MetadataToolSpec {
@@ -482,5 +555,17 @@ object MetadataToolSpec {
 
     files ++ compactFiles
   }
+
+  val versionLine: StringLine =
+    StringLine("v1")
+  val correctJsonLine: JsonLine =
+    JsonLine(parse("""{"path":"/some/path","key1":12345,"key2":true,"key3":"value3"}""").toOption.get)
+  val incorrectJsonLine: JsonLine =
+    JsonLine(parse("""{"key1":12345,"key2":true,"key3":"value3"}""").toOption.get)
+  val notJsonLine: StringLine =
+    StringLine("not, a, json")
+
+  def getParsingError(path: String): ParsingError =
+    ParsingError(s"File $path did not match expected format", None)
 
 }


### PR DESCRIPTION
Implements #41 
Verify the content of the files - spark metadata should consist of multiple lines: first line should be string and rest of the file should be JSON entries
- Fail on invalid content
- Both tools