### PR TITLE
#52 - 2 tests fails on windows due to path comparison

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,10 @@ lazy val root = (project in file("."))
 
 val patSettings = githubTokenSource := TokenSource.Or(
   TokenSource.Environment("GITHUB_TOKEN"), // Required for publishing
-  TokenSource.Environment("SHELL")         // Used to bypass PAT eager resolution for local development
+  TokenSource.Or(
+    TokenSource.Environment("SHELL"),      // Used to bypass PAT eager resolution for local development
+    TokenSource.GitConfig("github.token")  // Used on windows with IntelliJ due to known issue: https://github.com/djspiewak/sbt-github-packages/issues/26
+  )
 )
 
 val compilerOptions = Seq(

--- a/src/test/scala/za/co/absa/spark_metadata_tool/io/HdfsFileManagerSpec.scala
+++ b/src/test/scala/za/co/absa/spark_metadata_tool/io/HdfsFileManagerSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, EitherValues, OptionValues}
 
+import java.io.File
 import java.nio.file
 import java.nio.file.Paths
 import java.util.UUID
@@ -39,7 +40,9 @@ class HdfsFileManagerSpec extends AnyFlatSpec with Matchers with OptionValues wi
   miniDFSCluster.waitActive()
 
   val testDataFolder = "/hdfsTestData"
-  val testDataRootDir: String = getClass.getResource(testDataFolder).getPath
+  // getting absolute path and replacing actions are required to keep test running on windows too
+  val testDataRootDir: String = new File(getClass.getResource(testDataFolder).toURI).getAbsolutePath.
+    replace("\\", "/")
   val testDataHdfsRootDir: String = s"${miniDFSCluster.getFileSystem.getUri.toString}$testDataFolder"
   val topLevelDirOne: String = "dir1"
   val fileOneInDirOne: String = "testFile1.txt"


### PR DESCRIPTION
- extended githubTokenSource logic to solve problem with plugin `sbt-github-packages` on Windows with IntelliJ
- repaired 2 failing tests by new definition of data path

Closes #52 